### PR TITLE
Fix editor param change

### DIFF
--- a/src/development-tools/location-and-jump-stats.ts
+++ b/src/development-tools/location-and-jump-stats.ts
@@ -36,8 +36,8 @@ for (const origin of fs.readdirSync(dataSrcPath + "/qm")) {
 console.info("===========================");
 
 stats
-  //.sort((a, b) => a.quest.locations.length - b.quest.locations.length)
-  .sort((a, b) => a.quest.jumps.length - b.quest.jumps.length)
+  .sort((a, b) => a.quest.locations.length - b.quest.locations.length)
+  //.sort((a, b) => a.quest.jumps.length - b.quest.jumps.length)
   .forEach((stat) => {
     console.info(
       `${stat.name} loc=${stat.quest.locations.length} jumps=${stat.quest.jumps.length}`,

--- a/src/ui/editor/core/actions.ts
+++ b/src/ui/editor/core/actions.ts
@@ -292,6 +292,7 @@ export function updateParamWithFixMaxMin(
         idx === paramIdx
           ? {
               ...paramCondition,
+              // If condition was equal to max/min then update it to be new max/min
               mustFrom:
                 quest.params[paramIdx].min === paramCondition.mustFrom
                   ? newParam.min

--- a/src/ui/editor/core/actions.ts
+++ b/src/ui/editor/core/actions.ts
@@ -277,3 +277,32 @@ export function fixJumpParamMinMax(quest: Quest): Quest {
     })),
   };
 }
+
+export function updateParamWithFixMaxMin(
+  quest: Quest,
+  paramIdx: number,
+  newParam: DeepImmutable<QMParam>,
+): Quest {
+  return {
+    ...quest,
+    params: quest.params.map((param, idx) => (idx === paramIdx ? newParam : param)),
+    jumps: quest.jumps.map((j) => ({
+      ...j,
+      paramsConditions: j.paramsConditions.map((paramCondition, idx) =>
+        idx === paramIdx
+          ? {
+              ...paramCondition,
+              mustFrom:
+                quest.params[paramIdx].min === paramCondition.mustFrom
+                  ? newParam.min
+                  : paramCondition.mustFrom,
+              mustTo:
+                quest.params[paramIdx].max === paramCondition.mustTo
+                  ? newParam.max
+                  : paramCondition.mustTo,
+            }
+          : paramCondition,
+      ),
+    })),
+  };
+}

--- a/src/ui/editor/core/actions.ts
+++ b/src/ui/editor/core/actions.ts
@@ -264,20 +264,6 @@ export function removeLocation(quest: Quest, locationId: LocationId): Quest {
   };
 }
 
-export function fixJumpParamMinMax(quest: Quest): Quest {
-  return {
-    ...quest,
-    jumps: quest.jumps.map((j) => ({
-      ...j,
-      paramsConditions: j.paramsConditions.map((p, idx) => ({
-        ...p,
-        mustFrom: Math.max(p.mustFrom, quest.params[idx].min),
-        mustTo: Math.min(p.mustTo, quest.params[idx].max),
-      })),
-    })),
-  };
-}
-
 export function updateParamWithFixMaxMin(
   quest: Quest,
   paramIdx: number,
@@ -293,14 +279,15 @@ export function updateParamWithFixMaxMin(
           ? {
               ...paramCondition,
               // If condition was equal to max/min then update it to be new max/min
+              // If not then check that it is in the allowed range
               mustFrom:
                 quest.params[paramIdx].min === paramCondition.mustFrom
                   ? newParam.min
-                  : paramCondition.mustFrom,
+                  : Math.max(paramCondition.mustFrom, newParam.min),
               mustTo:
                 quest.params[paramIdx].max === paramCondition.mustTo
                   ? newParam.max
-                  : paramCondition.mustTo,
+                  : Math.min(paramCondition.mustTo, newParam.max),
             }
           : paramCondition,
       ),

--- a/src/ui/editor/core/actions.ts
+++ b/src/ui/editor/core/actions.ts
@@ -155,10 +155,12 @@ export function duplicateJump(
 }
 
 export function addParameter(quest: Quest): Quest {
+  const default_param_min = 0;
+  const default_param_max = 100;
   const newParam: DeepImmutable<QMParam> = {
     active: true,
-    min: 0,
-    max: 100,
+    min: default_param_min,
+    max: default_param_max,
     type: ParamType.Обычный,
     showWhenZero: true,
     critType: ParamCritType.Минимум,
@@ -170,8 +172,8 @@ export function addParameter(quest: Quest): Quest {
     }`,
     showingInfo: [
       {
-        from: 0,
-        to: 100,
+        from: default_param_min,
+        to: default_param_max,
         str: `Параметр ${quest.paramsCount + 1}: <>`,
       },
     ],
@@ -198,8 +200,8 @@ export function addParameter(quest: Quest): Quest {
 
   const createParameterCondition = () => {
     const condition: JumpParameterCondition = {
-      mustFrom: 0,
-      mustTo: 0,
+      mustFrom: default_param_min,
+      mustTo: default_param_max,
       mustEqualValues: [],
       mustEqualValuesEqual: true,
       mustModValues: [],

--- a/src/ui/editor/core/index.tsx
+++ b/src/ui/editor/core/index.tsx
@@ -10,7 +10,6 @@ import {
   createLocation,
   duplicateLocation,
   duplicateJump,
-  fixJumpParamMinMax,
   removeJump,
   removeLocation,
   updateJump,
@@ -835,8 +834,7 @@ export function EditorCore({
               onClose={(newQuest) => {
                 setOverlayMode(undefined);
                 if (newQuest) {
-                  const fixedParamsMinMax = fixJumpParamMinMax(newQuest);
-                  onChange(fixedParamsMinMax);
+                  onChange(newQuest);
                 }
               }}
               enableSaveOnNoChanges={overlayMode.enableSaveOnNoChanges}

--- a/src/ui/editor/core/overlays/questSettings/paramsSettings.tsx
+++ b/src/ui/editor/core/overlays/questSettings/paramsSettings.tsx
@@ -11,7 +11,7 @@ import {
   QMParamShowInfo,
   QMParamShowInfoPart,
 } from "../../../../../lib/qmreader";
-import { addParameter, removeLastParameter } from "../../actions";
+import { addParameter, removeLastParameter, updateParamWithFixMaxMin } from "../../actions";
 import { checkFormula, FormulaInput } from "../../common/formulaInput";
 import { getParamStringInfo } from "../../hovers/paramsAndChangeConditionsSummary";
 import { MediaEdit } from "../MediaEdit";
@@ -483,12 +483,7 @@ export function QuestParamsSettings({ quest, setQuest }: QuestSettingsTabProps) 
                   <QuestParamSettings
                     param={quest.params[paramId]}
                     setParam={(newParam) => {
-                      setQuest({
-                        ...quest,
-                        params: quest.params.map((param, idx) =>
-                          idx === paramId ? newParam : param,
-                        ),
-                      });
+                      setQuest(updateParamWithFixMaxMin(quest, paramId, newParam));
                     }}
                     quest={quest}
                   />


### PR DESCRIPTION
Small fixes to editor when param max/min are updated:
- If jump condition mustFrom/mustTo were equal to param min/max then keep them as min/max
- Keep jump condition mustFrom/mustTo inside param range

Also fixed default `mustTo` when new parameter is created